### PR TITLE
Add .gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Ignore build artifacts
+*.o
+*.obj
+*.lo
+*.la
+*.a
+*.so
+*.dll
+*.dylib
+*.exe
+*.out
+
+# Binaries
+hx
+hx_gtk
+hxd
+
+# Build directories
+build/
+build-*/
+
+# Autotools generated files
+Makefile
+config.h
+config.log
+config.status


### PR DESCRIPTION
## Summary
- ignore object files, binaries, and build directories
- ignore autotools-generated configuration files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68422c7327b483229a54fe27e83eb09c

## Summary by Sourcery

Enhancements:
- Add .gitignore to exclude object files, binaries, build directories, and autotools-generated configuration files.