### PR TITLE
Fix build error from truncated getopt_r.c

### DIFF
--- a/getopt_r.c
+++ b/getopt_r.c
@@ -1,10 +1,8 @@
-/*
- * Reentrant wrappers around the system getopt functions.
+/* Reentrant wrappers around getopt functions.
  *
- * These helpers call getopt(), getopt_long() or getopt_long_only()
- * and copy the global results into an opt_r structure so callers do
- * not rely on global variables.  They exist solely to satisfy code
- * originally written against the old GNU reentrant API.
+ * These helpers call getopt(), getopt_long() or getopt_long_only() and copy
+ * the global results into an opt_r structure. They are minimal replacements
+ * for the GNU getopt_r API used by older code.
  */
 
 #include <stddef.h>
@@ -12,51 +10,39 @@
 
 static int do_getopt_long_r(int argc, char *const argv[], const char *optstring,
                             const struct option *longopts, int *longind,
-                            int long_only, struct opt_r *opt);
+                            int long_only, struct opt_r *opt)
+{
+  int ret;
 
-int getopt_r(int argc, char *const argv[], const char *optstring,
-             struct opt_r *opt);
-
-int _getopt_r_internal(int argc, char *const argv[], const char *optstring,
-                       const struct option *longopts, int *longind,
-                       int long_only, struct opt_r *opt);
-
-static int
-do_getopt_long_r(int argc, char *const argv[], const char *optstring,
-                 const struct option *longopts, int *longind, int long_only,
-                 struct opt_r *opt)
   opterr = 0;
   optarg = NULL;
-  int ret;
+
   if (longopts == NULL) {
     ret = getopt(argc, argv, optstring);
   } else if (long_only) {
     ret = getopt_long_only(argc, argv, optstring, longopts, longind);
   } else {
     ret = getopt_long(argc, argv, optstring, longopts, longind);
+  }
+
   opt->arg = optarg;
   opt->ind = optind;
   opt->opt = ret;
+
   return ret;
-getopt_r(int argc, char *const argv[], const char *optstring,
-         struct opt_r *opt)
-  return do_getopt_long_r(argc, argv, optstring, NULL, NULL, 0, opt);
-_getopt_r_internal(int argc, char *const argv[], const char *optstring,
-                   const struct option *longopts, int *longind, int long_only,
-                   struct opt_r *opt)
-  return do_getopt_long_r(argc, argv, optstring, longopts, longind,
-                          long_only, opt);
-    }
-
-  if (opt.ind < argc)
-    {
-      printf ("non-option ARGV-elements: ");
-      while (opt.ind < argc)
-	printf ("%s ", argv[opt.ind++]);
-      printf ("\n");
-    }
-
-  exit (0);
 }
 
-#endif /* TEST */
+int getopt_r(int argc, char *const argv[], const char *optstring,
+             struct opt_r *opt)
+{
+  return do_getopt_long_r(argc, argv, optstring, NULL, NULL, 0, opt);
+}
+
+int _getopt_r_internal(int argc, char *const argv[], const char *optstring,
+                       const struct option *longopts, int *longind,
+                       int long_only, struct opt_r *opt)
+{
+  return do_getopt_long_r(argc, argv, optstring, longopts, longind, long_only,
+                          opt);
+}
+

--- a/getopt_r.c
+++ b/getopt_r.c
@@ -38,9 +38,9 @@ int getopt_r(int argc, char *const argv[], const char *optstring,
   return do_getopt_long_r(argc, argv, optstring, NULL, NULL, 0, opt);
 }
 
-int _getopt_r_internal(int argc, char *const argv[], const char *optstring,
-                       const struct option *longopts, int *longind,
-                       int long_only, struct opt_r *opt)
+static int _getopt_r_internal(int argc, char *const argv[], const char *optstring,
+                              const struct option *longopts, int *longind,
+                              int long_only, struct opt_r *opt)
 {
   return do_getopt_long_r(argc, argv, optstring, longopts, longind, long_only,
                           opt);


### PR DESCRIPTION
## Summary
- replace the corrupted `getopt_r.c` with a complete implementation
- rebuild project to verify compilation succeeds

## Testing
- `./configure`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_684389e2c6408322aae8a58f80d0825b

## Summary by Sourcery

Replace the truncated getopt_r.c with a complete implementation to restore successful builds

Bug Fixes:
- Fix build failure caused by a corrupted getopt_r.c file

Enhancements:
- Unify getopt, getopt_long, and getopt_long_only handling in a single do_getopt_long_r helper
- Refactor and clean up getopt_r and _getopt_r_internal wrappers for consistency