### PR TITLE
Fix getopt_r compilation failure

### DIFF
--- a/getopt_r.c
+++ b/getopt_r.c
@@ -38,9 +38,17 @@ int getopt_r(int argc, char *const argv[], const char *optstring,
   return do_getopt_long_r(argc, argv, optstring, NULL, NULL, 0, opt);
 }
 
-static int _getopt_r_internal(int argc, char *const argv[], const char *optstring,
-                              const struct option *longopts, int *longind,
-                              int long_only, struct opt_r *opt)
+/*
+ * Provide the _getopt_r_internal symbol expected by the legacy
+ * getopt wrapper functions in getopt1_r.c.  The prototype for this
+ * function is declared in getopt.h, so the definition here must not
+ * be static; otherwise GCC emits a conflicting declaration error when
+ * the header is included.  Keeping it non-static matches the header
+ * and allows older code to link correctly.
+ */
+int _getopt_r_internal(int argc, char *const argv[], const char *optstring,
+                       const struct option *longopts, int *longind,
+                       int long_only, struct opt_r *opt)
 {
   return do_getopt_long_r(argc, argv, optstring, longopts, longind, long_only,
                           opt);


### PR DESCRIPTION
## Summary
- fix prototype mismatch for `_getopt_r_internal` in getopt_r.c

## Testing
- `./configure`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6843916ed9e48322b65ba5649f43e93b

## Summary by Sourcery

Fix the linkage of the internal getopt function by aligning its definition with the header declaration

Bug Fixes:
- Remove the static qualifier from _getopt_r_internal to match its prototype in getopt.h and prevent GCC linkage errors

Enhancements:
- Add explanatory comment detailing why _getopt_r_internal must remain non-static for legacy compatibility