### PR TITLE
Fix release workflow YAML syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,30 +10,26 @@ jobs:
   build:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-
     strategy:
+      matrix:
         os:
           - ubuntu-latest
           - fedora-latest
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential autoconf automake libtool
-        run: |
-          sudo dnf install -y make automake gcc gcc-c++ kernel-devel \
-            autoconf libtool
 
-          tar czvf hx-${{ matrix.os }}-${{ github.ref_name }}.tar.gz \
-            -C dist .
+    steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Install build dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y build-essential autoconf automake libtool
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential autoconf automake libtool
 
       - name: Install build dependencies (Fedora)
         if: matrix.os == 'fedora-latest'
-        run: sudo dnf install -y make automake gcc gcc-c++ kernel-devel autoconf libtool
+        run: |
+          sudo dnf install -y make automake gcc gcc-c++ kernel-devel autoconf libtool
 
       - name: Build
         run: |
@@ -44,11 +40,11 @@ jobs:
         run: |
           mkdir -p dist
           cp hx dist/
-          tar czvf hx-${{ matrix.os }}.tar.gz -C dist .
+          tar czvf hx-${{ matrix.os }}-${{ github.ref_name }}.tar.gz -C dist .
 
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v2
         with:
-          files: hx-${{ matrix.os }}.tar.gz
+          files: hx-${{ matrix.os }}-${{ github.ref_name }}.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- correct GitHub Actions YAML syntax for release workflow
- ensure binary tarball names include OS and tag

## Testing
- `make -n` *(fails: No makefile)*
- `yamllint .github/workflows/release.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439d974ff483228309f309bc16c52a

## Summary by Sourcery

Fix GitHub Actions release workflow syntax and update tarball filenames to include both OS and release tag

Enhancements:
- Append ${{ github.ref_name }} to generated tarball filenames for both build and upload steps

CI:
- Correct strategy.matrix indentation and add missing steps section in release workflow YAML