### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,12 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential autoconf automake libtool
+          sudo apt-get install -y build-essential autoconf automake libtool libreadline-dev
 
       - name: Install build dependencies (Fedora)
         if: matrix.os == 'fedora-latest'
         run: |
-          sudo dnf install -y make automake gcc gcc-c++ kernel-devel autoconf libtool
+          sudo dnf install -y make automake gcc gcc-c++ kernel-devel autoconf libtool readline-devel
 
       - name: Build
         run: |


### PR DESCRIPTION
## Summary
- install GNU Readline in the GitHub Actions release workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68449010f30c8322b54e9243dffb7df6

## Summary by Sourcery

Install GNU Readline development libraries in the GitHub Actions release workflow for both Ubuntu and Fedora runners

CI:
- Add libreadline-dev to apt-get install on Ubuntu
- Add readline-devel to dnf install on Fedora